### PR TITLE
Remove authentication status card from AuthPage

### DIFF
--- a/components/pages/AuthPage.tsx
+++ b/components/pages/AuthPage.tsx
@@ -496,29 +496,7 @@ export function AuthPage() {
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.4 }}
           className="mt-8"
-        >
-          <Card className="p-6 bg-gradient-to-r from-green-50 to-blue-50 border-2 border-green-200">
-            <div className="text-center">
-              <AnimatedEmoji emoji="✅" animation="pulse" size="small" className="mb-3" />
-              <h3 className="font-bold text-green-800 mb-2">Authentication Ready</h3>
-              <p className="text-sm text-green-600 mb-3">
-                Complete authentication system with Google OAuth:
-              </p>
-              <div className="text-xs text-green-500 space-y-1">
-                <p>✅ Google OAuth is configured and ready</p>
-                <p>✅ Email/password authentication is enabled</p>
-                <p>✅ User data is automatically saved to Supabase</p>
-                <p>✅ Admin roles are supported through the database</p>
-                <p>✅ Session management and persistence</p>
-                <p>✅ Automatic profile creation on signup</p>
-              </div>
-              <div className="mt-3 text-xs text-green-400">
-                <AnimatedEmoji emoji="🔧" animation="wiggle" size="small" className="mr-1" />
-                Ready for production use with secure authentication flow
-              </div>
-            </div>
-          </Card>
-        </motion.div>
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
## Purpose
Based on the conversation history indicating visual changes were requested, this PR removes the authentication status information card that was displaying system readiness details on the authentication page.

## Code changes
- Removed the entire Card component displaying "Authentication Ready" status
- Eliminated the detailed checklist showing OAuth configuration, email/password auth, Supabase integration, admin roles, session management, and profile creation features
- Simplified the motion.div element by removing the card content while preserving the animation wrapper
- Cleaned up 22 lines of UI code that were showing authentication system capabilities

The AuthPage component now has a cleaner interface without the prominent status card that was previously informing users about the authentication system's readiness and features.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/049f3233bd3440b59f1730d1a8ec0411/zen-verse)

👀 [Preview Link](https://049f3233bd3440b59f1730d1a8ec0411-zen-verse.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>049f3233bd3440b59f1730d1a8ec0411</projectId>-->
<!--<branchName>zen-verse</branchName>-->