### PR TITLE
Replace Unsplash images with Pinterest images in product constants

### DIFF
--- a/components/constants.tsx
+++ b/components/constants.tsx
@@ -468,7 +468,7 @@ export const menProducts: ProductCategory[] = [
   {
     name: "Graphic Tees",
     icon: <Star className="w-5 h-5" />,
-    image: "https://images.unsplash.com/photo-1503341338985-b4c2a0c3e15b?q=80&w=2070&auto=format&fit=crop",
+    image: "https://i.pinimg.com/1200x/c1/13/cb/c113cb7f840da6b0bd52c808547cf612.jpg",
     description: "Trendy graphic designs for casual wear",
     itemCount: "30+ graphics",
     price: "$26",


### PR DESCRIPTION
## Purpose
Based on the conversation context referencing ProductGrid.tsx and visual changes, the user intended to update product images to improve the visual presentation of the product grid component.

## Code changes
- Replaced 10 Unsplash image URLs with Pinterest image URLs across multiple product categories
- Updated images for summer products: Beach T-Shirts and Tank Tops
- Updated images for men's products: Summer T-Shirts, Cargo Shorts, Polo Shirts, Board Shorts, Tank Tops, Linen Shirts, Athletic Shorts, and Graphic Tees
- All image URLs now point to Pinterest (i.pinimg.com) instead of Unsplash (images.unsplash.com)
- Product descriptions, pricing, and other metadata remain unchanged

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 15`

🔗 [Edit in Builder.io](https://builder.io/app/projects/b061395790814425b031b73d47e8973b/orbit-haven)

👀 [Preview Link](https://b061395790814425b031b73d47e8973b-orbit-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>b061395790814425b031b73d47e8973b</projectId>-->
<!--<branchName>orbit-haven</branchName>-->