### PR TITLE
Fix buy now button to add product to cart and navigate

### DIFF
--- a/components/pages/ProductDetailPage.tsx
+++ b/components/pages/ProductDetailPage.tsx
@@ -500,8 +500,10 @@ export function ProductDetailPage({ setCurrentPage }: ProductDetailPageProps) {
                   </Button>
                 </motion.div>
                 <motion.div whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }}>
-                  <Button 
-                    variant="outline" 
+                  <Button
+                    variant="outline"
+                    onClick={handleBuyNow}
+                    disabled={!product.inStock || !selectedSize}
                     className="h-12 rounded-full font-bold hover:bg-purple-50 w-full border-2 border-amber-300 hover:border-purple-400"
                   >
                     Buy Now

--- a/components/pages/ProductDetailPage.tsx
+++ b/components/pages/ProductDetailPage.tsx
@@ -142,6 +142,29 @@ export function ProductDetailPage({ setCurrentPage }: ProductDetailPageProps) {
     }
   };
 
+  const handleBuyNow = () => {
+    if (!selectedSize) {
+      alert("Please select a size");
+      return;
+    }
+
+    // Add the product to cart
+    for (let i = 0; i < quantity; i++) {
+      addToCart({
+        id: `${product.id}-${Date.now()}-${i}`,
+        name: product.name,
+        price: product.price,
+        image: product.images[0],
+        size: selectedSize,
+        color: selectedColor.name,
+        category: product.category
+      });
+    }
+
+    // Navigate to cart page
+    setCurrentPage("cart");
+  };
+
   const handleWishlistToggle = () => {
     const wishlistItem = {
       id: product.id,


### PR DESCRIPTION
## Purpose
Fix the "buy now" button functionality to properly add the selected product to the cart and navigate the user to the cart page, as requested to resolve the bug where clicking "buy now" didn't lead to the cart with the product.

## Code changes
- Added `handleBuyNow` function that validates size selection, adds the product to cart with specified quantity, and navigates to cart page
- Connected the buy now button's `onClick` event to the new handler function
- Added proper disabled state for the button when product is out of stock or no size is selected
- Ensured product details (size, color, quantity) are preserved when adding to cart

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 24`

🔗 [Edit in Builder.io](https://builder.io/app/projects/82d3f861de394f5f8a1d0216adfff435/spark-oasis)

👀 [Preview Link](https://82d3f861de394f5f8a1d0216adfff435-spark-oasis.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>82d3f861de394f5f8a1d0216adfff435</projectId>-->
<!--<branchName>spark-oasis</branchName>-->