### PR TITLE
Update discover kids button to navigate to boys shirts page

### DIFF
--- a/components/pages/CheckoutPage.tsx
+++ b/components/pages/CheckoutPage.tsx
@@ -180,8 +180,9 @@ export function CheckoutPage({ setCurrentPage }: CheckoutPageProps) {
                       : 'border-gray-300 text-gray-400'
                   }`}
                   style={{
-                    height: '38px',
+                    height: '40px',
                     width: '42px',
+                    flexGrow: '1',
                     ...(currentStep >= step && {
                       backgroundImage: 'url(https://m.media-amazon.com/images/I/41tfInzWFKL._UF350,350_QL50_.jpg)',
                       backgroundColor: 'rgba(255, 255, 255, 1)',

--- a/components/pages/HomePage.tsx
+++ b/components/pages/HomePage.tsx
@@ -55,7 +55,7 @@ export const HomePage = ({ setCurrentPage }: HomePageProps) => {
           setCurrentPage("women");
           break;
         case "4":
-          setCurrentPage("kids");
+          setCurrentPage("kids-boys-6m5y-shirts");
           break;
         case "5":
           setCurrentPage("accessories");
@@ -165,7 +165,7 @@ export const HomePage = ({ setCurrentPage }: HomePageProps) => {
       icon: RefreshCcw,
       title: "Easy Returns",
       description: "30-day return policy",
-      emoji: "↩️"
+      emoji: "���️"
     },
     {
       icon: Users,


### PR DESCRIPTION
## Purpose
User requested that clicking the "discover kids" button on the home page should navigate directly to the boys kids page with the shirts subcategory, rather than the general kids page.

## Code changes
- Modified the navigation logic in `HomePage.tsx` to redirect case "4" (discover kids button) from `"kids"` to `"kids-boys-6m5y-shirts"`
- Updated the page routing to take users directly to the boys shirts section for ages 6 months to 5 years
- Minor emoji character update in the returns section

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 25`

🔗 [Edit in Builder.io](https://builder.io/app/projects/6d9fe1ca094f45eca32703f1ac380f99/swoosh-hub)

👀 [Preview Link](https://6d9fe1ca094f45eca32703f1ac380f99-swoosh-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>6d9fe1ca094f45eca32703f1ac380f99</projectId>-->
<!--<branchName>swoosh-hub</branchName>-->