### PR TITLE
Optimize mobile UI: 2 products per row and smaller title

### DIFF
--- a/components/HeroCarousel.tsx
+++ b/components/HeroCarousel.tsx
@@ -95,15 +95,15 @@ export const HeroCarousel = ({
       {
         breakpoint: 768,
         settings: {
-          slidesToShow: 2,
-          centerMode: false,
-          centerPadding: "0px",
+          slidesToShow: 1,
+          centerMode: true,
+          centerPadding: "40px",
         }
       },
       {
         breakpoint: 480,
         settings: {
-          slidesToShow: 2,
+          slidesToShow: 1,
           centerMode: false,
           centerPadding: "0px",
         }
@@ -302,10 +302,10 @@ export const HeroCarousel = ({
           transform: scale(0.95);
         }
       `}</style>
-      <div className="relative hero-carousel h-[360px] sm:h-[420px] md:h-[480px] lg:h-[500px]">
+      <div className="h-[500px] relative hero-carousel">
         <Slider {...settings} className="h-full">
           {slides.map((slide, index) => (
-            <div key={slide.id} className="h-full px-1.5 sm:px-2 md:px-3">
+            <div key={slide.id} className="px-3 h-[500px]">
               <motion.div
                 initial={{ opacity: 0, y: 20 }}
                 animate={{ opacity: 1, y: 0 }}

--- a/components/HeroCarousel.tsx
+++ b/components/HeroCarousel.tsx
@@ -95,15 +95,15 @@ export const HeroCarousel = ({
       {
         breakpoint: 768,
         settings: {
-          slidesToShow: 1,
-          centerMode: true,
-          centerPadding: "40px",
+          slidesToShow: 2,
+          centerMode: false,
+          centerPadding: "0px",
         }
       },
       {
         breakpoint: 480,
         settings: {
-          slidesToShow: 1,
+          slidesToShow: 2,
           centerMode: false,
           centerPadding: "0px",
         }
@@ -302,10 +302,10 @@ export const HeroCarousel = ({
           transform: scale(0.95);
         }
       `}</style>
-      <div className="h-[500px] relative hero-carousel">
+      <div className="relative hero-carousel h-[360px] sm:h-[420px] md:h-[480px] lg:h-[500px]">
         <Slider {...settings} className="h-full">
           {slides.map((slide, index) => (
-            <div key={slide.id} className="px-3 h-[500px]">
+            <div key={slide.id} className="h-full px-1.5 sm:px-2 md:px-3">
               <motion.div
                 initial={{ opacity: 0, y: 20 }}
                 animate={{ opacity: 1, y: 0 }}

--- a/components/ProductGrid.tsx
+++ b/components/ProductGrid.tsx
@@ -276,7 +276,7 @@ export function ProductGrid({ title, subtitle, products }: {
           initial="hidden"
           whileInView="visible"
           viewport={{ once: true, margin: "-100px" }}
-          className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-8"
+          className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-4 gap-4 sm:gap-6 md:gap-8"
         >
           {products.map((product, index) => {
             const productId = product.id || `${product.name.toLowerCase().replace(/\s+/g, '-')}-001`;
@@ -325,9 +325,9 @@ export function ProductGrid({ title, subtitle, products }: {
                   </motion.div>
                 )}
 
-                <div className="relative p-6">
+                <div className="relative p-4 sm:p-6">
                   <div className="mb-6">
-                    <div className="relative h-64 w-full rounded-lg overflow-hidden mb-4">
+                    <div className="relative h-40 sm:h-56 md:h-64 w-full rounded-lg overflow-hidden mb-3 sm:mb-4">
                       <motion.img
                         src={product.image}
                         alt={product.name}
@@ -377,7 +377,7 @@ export function ProductGrid({ title, subtitle, products }: {
                       </div>
                     </div>
                     <motion.h3 
-                      className="font-bold text-xl text-zinc-900 dark:text-white text-center mb-2"
+                      className="font-bold text-base sm:text-xl text-zinc-900 dark:text-white text-center mb-2"
                       initial={{ opacity: 0 }}
                       whileInView={{ opacity: 1 }}
                       viewport={{ once: true }}
@@ -386,7 +386,7 @@ export function ProductGrid({ title, subtitle, products }: {
                       {product.name}
                     </motion.h3>
                     <motion.p 
-                      className="font-medium text-zinc-600 dark:text-zinc-400 text-center text-sm mb-2"
+                      className="font-medium text-zinc-600 dark:text-zinc-400 text-center text-xs sm:text-sm mb-2"
                       initial={{ opacity: 0 }}
                       whileInView={{ opacity: 1 }}
                       viewport={{ once: true }}
@@ -395,7 +395,7 @@ export function ProductGrid({ title, subtitle, products }: {
                       {product.description}
                     </motion.p>
                     <motion.p 
-                      className="font-bold text-xs text-amber-600 text-center flex items-center justify-center gap-1"
+                      className="font-bold text-[11px] sm:text-xs text-amber-600 text-center flex items-center justify-center gap-1"
                       initial={{ opacity: 0 }}
                       whileInView={{ opacity: 1 }}
                       viewport={{ once: true }}
@@ -419,7 +419,7 @@ export function ProductGrid({ title, subtitle, products }: {
                     >
                       <Button
                         onClick={(e) => handleAddToCart(product, e)}
-                        className={`w-full h-10 font-bold relative
+                        className={`w-full h-9 sm:h-10 font-bold relative
                         border-2 border-amber-600 dark:border-amber-400
                         transition-all duration-200 flex items-center justify-center gap-2
                         shadow-[4px_4px_0px_0px] shadow-amber-600 dark:shadow-amber-400
@@ -449,7 +449,7 @@ export function ProductGrid({ title, subtitle, products }: {
                       <Button
                         onClick={(e) => handleWishlistToggle(product, e)}
                         variant="outline"
-                          className={`w-full h-9 font-bold relative transition-all duration-200 flex items-center justify-center gap-1 border-2 text-xs ${
+                          className={`w-full h-8 sm:h-9 font-bold relative transition-all duration-200 flex items-center justify-center gap-1 border-2 text-xs ${
                           inWishlist
                             ? "border-rose-400 bg-rose-50 text-rose-700 hover:bg-rose-100 hover:border-rose-500"
                             : "border-amber-400 bg-white text-amber-700 hover:bg-amber-50 hover:border-amber-500"
@@ -473,7 +473,7 @@ export function ProductGrid({ title, subtitle, products }: {
                         <Button
                           onClick={(e) => handleWriteReview(product, e)}
                           variant="outline"
-                          className="w-full h-9 font-bold relative transition-all duration-200 flex items-center justify-center gap-1 border-2 border-blue-400 bg-white text-blue-700 hover:bg-blue-50 hover:border-blue-500 text-xs"
+                          className="w-full h-8 sm:h-9 font-bold relative transition-all duration-200 flex items-center justify-center gap-1 border-2 border-blue-400 bg-white text-blue-700 hover:bg-blue-50 hover:border-blue-500 text-xs"
                         >
                           <MessageSquare className="w-3 h-3" />
                           Review

--- a/components/pages/HomePage.tsx
+++ b/components/pages/HomePage.tsx
@@ -357,7 +357,7 @@ export const HomePage = ({ setCurrentPage }: HomePageProps) => {
               />
               
               <motion.h1 
-                className="relative text-4xl md:text-6xl font-black mb-4 flex items-center justify-center gap-3"
+                className="relative text-3xl md:text-6xl font-black mb-4 flex items-center justify-center gap-3"
                 initial={{ opacity: 0, scale: 0.9 }}
                 animate={{ opacity: 1, scale: 1 }}
                 transition={{ duration: 1, delay: 0.4, type: "spring", stiffness: 120 }}

--- a/components/pages/HomePage.tsx
+++ b/components/pages/HomePage.tsx
@@ -618,7 +618,7 @@ export const HomePage = ({ setCurrentPage }: HomePageProps) => {
             </motion.p>
           </motion.div>
 
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+          <div className="grid grid-cols-2 md:grid-cols-2 lg:grid-cols-4 gap-4 sm:gap-6">
             {featuredProducts.map((product, index) => (
               <motion.div
                 key={product.id}
@@ -634,7 +634,7 @@ export const HomePage = ({ setCurrentPage }: HomePageProps) => {
                   <ImageWithFallback
                     src={product.image}
                     alt={product.name}
-                    className="w-full h-64 object-cover group-hover:scale-110 transition-transform duration-500"
+                    className="w-full h-40 sm:h-56 md:h-64 object-cover group-hover:scale-110 transition-transform duration-500"
                   />
                   <div className="absolute top-3 left-3 bg-white/90 backdrop-blur-sm rounded-full px-3 py-1 text-xs font-bold text-amber-600">
                     {product.badge}
@@ -652,7 +652,7 @@ export const HomePage = ({ setCurrentPage }: HomePageProps) => {
                   </motion.button>
                 </div>
                 
-                <div className="px-6 pt-6 pb-6" style={{ paddingBottom: '23px' }}>
+                <div className="px-4 pt-4 pb-5 sm:px-6 sm:pt-6 sm:pb-6" style={{ paddingBottom: '23px' }}>
                   <div className="flex items-center gap-2 mb-2">
                     <div className="flex items-center">
                       {[...Array(5)].map((_, i) => (
@@ -672,17 +672,17 @@ export const HomePage = ({ setCurrentPage }: HomePageProps) => {
                   </div>
                   
                   <motion.h3 
-                    className="text-lg font-black text-zinc-900 mb-2 group-hover:text-transparent group-hover:bg-clip-text group-hover:bg-gradient-to-r group-hover:from-amber-600 group-hover:to-purple-600"
+                    className="text-base sm:text-lg font-black text-zinc-900 mb-2 group-hover:text-transparent group-hover:bg-clip-text group-hover:bg-gradient-to-r group-hover:from-amber-600 group-hover:to-purple-600"
                     whileHover={{ scale: 1.05 }}
                   >
                     {product.name}
                   </motion.h3>
                   
-                  <p className="text-sm text-gray-600 mb-4">{product.category}</p>
+                  <p className="text-xs sm:text-sm text-gray-600 mb-4">{product.category}</p>
                   
                   <div className="flex items-center justify-between mb-4">
                     <div className="flex items-center gap-2">
-                      <span className="text-xl font-black text-transparent bg-clip-text bg-gradient-to-r from-amber-600 to-purple-600">
+                      <span className="text-lg sm:text-xl font-black text-transparent bg-clip-text bg-gradient-to-r from-amber-600 to-purple-600">
                         ${product.price}
                       </span>
                       <span className="text-sm text-gray-500 line-through">
@@ -701,7 +701,7 @@ export const HomePage = ({ setCurrentPage }: HomePageProps) => {
                       e.stopPropagation();
                       handleAddToCart(product);
                     }}
-                    className="w-full bg-gradient-to-r from-amber-500 to-purple-500 hover:from-amber-600 hover:to-purple-600 text-white py-3 rounded-xl font-medium transition-all duration-200 flex items-center justify-center gap-2 shadow-md hover:shadow-lg"
+                    className="w-full bg-gradient-to-r from-amber-500 to-purple-500 hover:from-amber-600 hover:to-purple-600 text-white py-2.5 sm:py-3 rounded-xl font-medium transition-all duration-200 flex items-center justify-center gap-2 shadow-md hover:shadow-lg"
                   >
                     <ShoppingBag className="w-4 h-4" />
                     Add to Cart

--- a/components/pages/HomePage.tsx
+++ b/components/pages/HomePage.tsx
@@ -357,7 +357,7 @@ export const HomePage = ({ setCurrentPage }: HomePageProps) => {
               />
               
               <motion.h1 
-                className="relative text-3xl md:text-6xl font-black mb-4 flex items-center justify-center gap-3"
+                className="relative text-2xl sm:text-3xl md:text-6xl font-black mb-4 flex items-center justify-center gap-3"
                 initial={{ opacity: 0, scale: 0.9 }}
                 animate={{ opacity: 1, scale: 1 }}
                 transition={{ duration: 1, delay: 0.4, type: "spring", stiffness: 120 }}
@@ -401,24 +401,29 @@ export const HomePage = ({ setCurrentPage }: HomePageProps) => {
                     }}
                   >
                     {/* Typewriter Effect */}
-                    {"Welcome to Outlander".split("").map((char, index) => (
-                      <motion.span
-                        key={index}
-                        initial={{ opacity: 0, y: 10 }}
-                        animate={{ opacity: 1, y: 0 }}
-                        transition={{
-                          duration: 0.1,
-                          delay: 0.8 + index * 0.04,
-                          ease: "easeOut"
-                        }}
-                        whileHover={{
-                          y: -2,
-                          transition: { duration: 0.2 }
-                        }}
-                        className="inline-block cursor-pointer"
-                      >
-                        {char === " " ? "\u00A0" : char}
-                      </motion.span>
+                    {["Welcome", "to", "Outlander"].map((word, wIndex, arr) => (
+                      <span key={wIndex} className={word === "Outlander" ? "inline-flex whitespace-nowrap" : "inline-flex"}>
+                        {word.split("").map((char, index) => (
+                          <motion.span
+                            key={`${wIndex}-${index}`}
+                            initial={{ opacity: 0, y: 10 }}
+                            animate={{ opacity: 1, y: 0 }}
+                            transition={{
+                              duration: 0.1,
+                              delay: 0.8 + wIndex * 0.2 + index * 0.04,
+                              ease: "easeOut"
+                            }}
+                            whileHover={{
+                              y: -2,
+                              transition: { duration: 0.2 }
+                            }}
+                            className="inline-block cursor-pointer"
+                          >
+                            {char}
+                          </motion.span>
+                        ))}
+                        {wIndex < arr.length - 1 && <span className="inline-block">&nbsp;</span>}
+                      </span>
                     ))}
                   </motion.span>
 


### PR DESCRIPTION
## Purpose
The user requested mobile UI improvements to enhance the shopping experience on mobile devices. The main goals were to:
- Display 2 products per row instead of 1 on mobile screens for better product visibility
- Make the "Welcome to Outlander" title smaller and prevent word splitting on mobile
- Apply these changes across all product grids (home page, men's, women's, kids, accessories categories)

## Code changes
- **ProductGrid.tsx**: Updated grid layout from `grid-cols-1` to `grid-cols-2` for mobile, adjusted responsive breakpoints, and reduced padding, image heights, font sizes, and button heights for mobile screens
- **HomePage.tsx**: 
  - Reduced hero title font size from `text-4xl` to `text-2xl` on mobile
  - Modified "Welcome to Outlander" text rendering to prevent word splitting using `whitespace-nowrap` for "Outlander"
  - Updated featured products grid to show 2 columns on mobile with smaller spacing and responsive sizing for images, text, and buttons

These changes ensure users can see 2 products at once on mobile while maintaining readability and usability across all device sizes.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 28`

🔗 [Edit in Builder.io](https://builder.io/app/projects/9de2b739fb0c4ac89ddaa0830537e002/pulse-sanctuary)

👀 [Preview Link](https://9de2b739fb0c4ac89ddaa0830537e002-pulse-sanctuary.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>9de2b739fb0c4ac89ddaa0830537e002</projectId>-->
<!--<branchName>pulse-sanctuary</branchName>-->